### PR TITLE
[BUGFIX] findAllLabels() always returns array

### DIFF
--- a/Classes/Domain/Repository/Hubspot/CustomObjectSchemaRepository.php
+++ b/Classes/Domain/Repository/Hubspot/CustomObjectSchemaRepository.php
@@ -83,7 +83,7 @@ class CustomObjectSchemaRepository extends AbstractHubspotRepository
         if (!$cached || !is_array($schemaLabels)) {
             $this->findAll(false);
 
-            $schemaLabels = $this->registry->get('hubspot', self::REGISTRY_CUSTOM_OBJECT_SCHEMA);
+            $schemaLabels = $this->registry->get('hubspot', self::REGISTRY_CUSTOM_OBJECT_SCHEMA) ?? [];
         }
 
         return $schemaLabels;


### PR DESCRIPTION
Fixes an issue where fetching custom object labels wasn't possible the first time the extension was loaded in a new instance.