### PR TITLE
[BUGFIX] Sync pass identifier out of scope

### DIFF
--- a/Classes/Domain/Repository/Database/MappedTableRepository.php
+++ b/Classes/Domain/Repository/Database/MappedTableRepository.php
@@ -122,7 +122,7 @@ class MappedTableRepository extends AbstractDatabaseRepository
                 'table_foreign' => $this->tableName,
                 'hubspot_created_timestamp' => time() * 1000,
                 'hubspot_sync_timestamp' => time(),
-                'hubspot_sync_pass' => 1,
+                'hubspot_sync_pass' => $this->getSyncPassIdentifier(),
             ])
             ->execute();
     }
@@ -206,7 +206,24 @@ class MappedTableRepository extends AbstractDatabaseRepository
                 $queryBuilder->expr()->max('hubspot_sync_pass'),
                 $queryBuilder->expr()->min('hubspot_sync_pass')
             )
-            ->andWhere($queryBuilder->expr()->neq('hubspot_id', 0))
+            ->where(
+                $queryBuilder->expr()->neq(
+                    'hubspot_id',
+                    0
+                ),
+                $queryBuilder->expr()->eq(
+                    'object_type',
+                    $queryBuilder->createNamedParameter($this->objectType)
+                ),
+                $queryBuilder->expr()->eq(
+                    'typoscript_key',
+                    $queryBuilder->createNamedParameter($this->typoScriptKey)
+                ),
+                $queryBuilder->expr()->eq(
+                    'table_foreign',
+                    $queryBuilder->createNamedParameter($this->tableName)
+                )
+            )
             ->from(self::RELATION_TABLE)
             ->execute()
             ->fetch(\PDO::FETCH_NUM);

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.14",
         "typo3/testing-framework": "^2 || ^4.9 || ^5.0 || ^6.2",
-        "overtrue/phplint": "^1.1"
+        "overtrue/phplint": "^1.1",
+        "phpspec/prophecy": "^1.15"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Sync pass identifiers for custom objects are now unique for object type, typoscript key, and foreign table. A valid sync pass identifier is also set when a mapping record is created. This should avoid "sync pass identifier out of scope" exceptions.