### PR TITLE
[BUGFIX] Ignore new records when getting sync pass ID

### DIFF
--- a/Classes/Domain/Repository/Database/FrontendUserRepository.php
+++ b/Classes/Domain/Repository/Database/FrontendUserRepository.php
@@ -241,6 +241,7 @@ class FrontendUserRepository extends AbstractDatabaseRepository
                 $queryBuilder->expr()->max('hubspot_sync_pass'),
                 $queryBuilder->expr()->min('hubspot_sync_pass')
             )
+            ->andWhere($queryBuilder->expr()->neq('hubspot_sync_pass', 0))
             ->from(static::TABLE_NAME)
             ->execute()
             ->fetch(\PDO::FETCH_NUM);

--- a/Classes/Domain/Repository/Database/MappedTableRepository.php
+++ b/Classes/Domain/Repository/Database/MappedTableRepository.php
@@ -208,6 +208,10 @@ class MappedTableRepository extends AbstractDatabaseRepository
             )
             ->where(
                 $queryBuilder->expr()->neq(
+                    'hubspot_sync_pass',
+                    0
+                ),
+                $queryBuilder->expr()->neq(
                     'hubspot_id',
                     0
                 ),


### PR DESCRIPTION
New records created externally will have their sync pass ID set to zero. Therefore, sync pass ID zero must be ignored when generating a new sync pass ID.